### PR TITLE
feat: Allow returning of errors from fields thunk

### DIFF
--- a/definition_test.go
+++ b/definition_test.go
@@ -603,7 +603,7 @@ func TestTypeSystem_DefinitionExample_IncludesFieldsThunk(t *testing.T) {
 	var someObject *graphql.Object
 	someObject = graphql.NewObject(graphql.ObjectConfig{
 		Name: "SomeObject",
-		Fields: (graphql.FieldsThunk)(func() graphql.Fields {
+		Fields: (graphql.FieldsThunk)(func() (graphql.Fields, error) {
 			return graphql.Fields{
 				"f": &graphql.Field{
 					Type: graphql.Int,
@@ -611,7 +611,7 @@ func TestTypeSystem_DefinitionExample_IncludesFieldsThunk(t *testing.T) {
 				"s": &graphql.Field{
 					Type: someObject,
 				},
-			}
+			}, nil
 		}),
 	})
 	fieldMap := someObject.Fields()
@@ -623,7 +623,7 @@ func TestTypeSystem_DefinitionExample_IncludesFieldsThunk(t *testing.T) {
 func TestTypeSystem_DefinitionExampe_AllowsCyclicFieldTypes(t *testing.T) {
 	personType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Person",
-		Fields: (graphql.FieldsThunk)(func() graphql.Fields {
+		Fields: (graphql.FieldsThunk)(func() (graphql.Fields, error) {
 			return graphql.Fields{
 				"name": &graphql.Field{
 					Type: graphql.String,
@@ -631,7 +631,7 @@ func TestTypeSystem_DefinitionExampe_AllowsCyclicFieldTypes(t *testing.T) {
 				"bestFriend": &graphql.Field{
 					Type: personType,
 				},
-			}
+			}, nil
 		}),
 	})
 

--- a/executor_test.go
+++ b/executor_test.go
@@ -2146,8 +2146,8 @@ func testErrors(t *testing.T, nameType graphql.Output, extensions map[string]int
 
 	heroType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Hero",
-		Fields: graphql.FieldsThunk(func() graphql.Fields {
-			return heroFields
+		Fields: graphql.FieldsThunk(func() (graphql.Fields, error) {
+			return heroFields, nil
 		}),
 	})
 

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/rules_overlapping_fields_can_be_merged_test.go
+++ b/rules_overlapping_fields_can_be_merged_test.go
@@ -408,7 +408,7 @@ func init() {
 		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
 			return stringBoxObject
 		},
-		Fields: graphql.FieldsThunk(func() graphql.Fields {
+		Fields: graphql.FieldsThunk(func() (graphql.Fields, error) {
 			return graphql.Fields{
 				"deepBox": &graphql.Field{
 					Type: someBoxInterface,
@@ -416,7 +416,7 @@ func init() {
 				"unrelatedField": &graphql.Field{
 					Type: graphql.String,
 				},
-			}
+			}, nil
 		}),
 	})
 	stringBoxObject = graphql.NewObject(graphql.ObjectConfig{
@@ -424,7 +424,7 @@ func init() {
 		Interfaces: (graphql.InterfacesThunk)(func() []*graphql.Interface {
 			return []*graphql.Interface{someBoxInterface}
 		}),
-		Fields: graphql.FieldsThunk(func() graphql.Fields {
+		Fields: graphql.FieldsThunk(func() (graphql.Fields, error) {
 			return graphql.Fields{
 				"scalar": &graphql.Field{
 					Type: graphql.String,
@@ -444,7 +444,7 @@ func init() {
 				"intBox": &graphql.Field{
 					Type: intBoxObject,
 				},
-			}
+			}, nil
 		}),
 	})
 	intBoxObject = graphql.NewObject(graphql.ObjectConfig{
@@ -452,7 +452,7 @@ func init() {
 		Interfaces: (graphql.InterfacesThunk)(func() []*graphql.Interface {
 			return []*graphql.Interface{someBoxInterface}
 		}),
-		Fields: graphql.FieldsThunk(func() graphql.Fields {
+		Fields: graphql.FieldsThunk(func() (graphql.Fields, error) {
 			return graphql.Fields{
 				"scalar": &graphql.Field{
 					Type: graphql.Int,
@@ -472,7 +472,7 @@ func init() {
 				"intBox": &graphql.Field{
 					Type: intBoxObject,
 				},
-			}
+			}, nil
 		}),
 	})
 	var nonNullStringBox1Interface = graphql.NewInterface(graphql.InterfaceConfig{

--- a/validation_test.go
+++ b/validation_test.go
@@ -1388,24 +1388,24 @@ func TestTypeSystem_ObjectsMustAdhereToInterfaceTheyImplement_AcceptsAnObjectWit
 		ResolveType: func(p graphql.ResolveTypeParams) *graphql.Object {
 			return nil
 		},
-		Fields: (graphql.FieldsThunk)(func() graphql.Fields {
+		Fields: (graphql.FieldsThunk)(func() (graphql.Fields, error) {
 			return graphql.Fields{
 				"field": &graphql.Field{
 					Type: anotherInterface,
 				},
-			}
+			}, nil
 		}),
 	})
 	var anotherObject *graphql.Object
 	anotherObject = graphql.NewObject(graphql.ObjectConfig{
 		Name:       "AnotherObject",
 		Interfaces: []*graphql.Interface{anotherInterface},
-		Fields: (graphql.FieldsThunk)(func() graphql.Fields {
+		Fields: (graphql.FieldsThunk)(func() (graphql.Fields, error) {
 			return graphql.Fields{
 				"field": &graphql.Field{
 					Type: anotherObject,
 				},
-			}
+			}, nil
 		}),
 	})
 	_, err := schemaWithFieldType(anotherObject)


### PR DESCRIPTION
Part of https://github.com/sourcenetwork/defradb/pull/61 - and brought into defra via https://github.com/sourcenetwork/defradb/pull/66
Allows proper handling of errors from field thunks (instead of ignoring/panicing).

I wanted to get rid of the lazy resolution completely but that turning into a real pain and a very broad set of changes that would risk causing problems with any future upstream changes (and potentially introducing bugs).