### PR TITLE
fix: Allow return of errors from input object thunk

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -1135,7 +1135,7 @@ func (st *InputObjectField) Error() error {
 
 type InputObjectConfigFieldMap map[string]*InputObjectFieldConfig
 type InputObjectFieldMap map[string]*InputObjectField
-type InputObjectConfigFieldMapThunk func() InputObjectConfigFieldMap
+type InputObjectConfigFieldMapThunk func() (InputObjectConfigFieldMap, error)
 type InputObjectConfig struct {
 	Name        string      `json:"name"`
 	Fields      interface{} `json:"fields"`
@@ -1163,7 +1163,11 @@ func (gt *InputObject) defineFieldMap() InputObjectFieldMap {
 	case InputObjectConfigFieldMap:
 		fieldMap = fields
 	case InputObjectConfigFieldMapThunk:
-		fieldMap = fields()
+		fieldMap, err = fields()
+		if err != nil {
+			gt.err = err
+			return InputObjectFieldMap{}
+		}
 	}
 	resultFieldMap := InputObjectFieldMap{}
 

--- a/validation_test.go
+++ b/validation_test.go
@@ -656,12 +656,12 @@ func TestTypeSystem_InputObjectsMustHaveFields_AcceptsAnInputObjectTypeWithField
 func TestTypeSystem_InputObjectsMustHaveFields_AcceptsAnInputObjectTypeWithAFieldFunction(t *testing.T) {
 	_, err := schemaWithInputObject(graphql.NewInputObject(graphql.InputObjectConfig{
 		Name: "SomeInputObject",
-		Fields: (graphql.InputObjectConfigFieldMapThunk)(func() graphql.InputObjectConfigFieldMap {
+		Fields: (graphql.InputObjectConfigFieldMapThunk)(func() (graphql.InputObjectConfigFieldMap, error) {
 			return graphql.InputObjectConfigFieldMap{
 				"f": &graphql.InputObjectFieldConfig{
 					Type: graphql.String,
 				},
-			}
+			}, nil
 		}),
 	}))
 	if err != nil {


### PR DESCRIPTION
Prerequisite to fixing https://github.com/sourcenetwork/defradb/issues/112

Tested by hooking up defra to this branch