### PR TITLE
fix: Define field args in deterministic order

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"sort"
+	"strings"
 
 	"github.com/graphql-go/graphql/language/ast"
 )
@@ -588,6 +590,12 @@ func defineFieldMap(ttype Named, fieldMap Fields) (FieldDefinitionMap, error) {
 			}
 			fieldDef.Args = append(fieldDef.Args, fieldArg)
 		}
+
+		// Sort args so that their order is deterministic (alpha-numeric descending)
+		sort.Slice(fieldDef.Args, func(i, j int) bool {
+			return strings.Compare(fieldDef.Args[i].Name(), fieldDef.Args[j].Name()) == -1
+		})
+
 		resultFieldMap[fieldName] = fieldDef
 	}
 	return resultFieldMap, nil

--- a/introspection.go
+++ b/introspection.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 
 	"github.com/graphql-go/graphql/language/ast"
 	"github.com/graphql-go/graphql/language/printer"
@@ -618,6 +619,12 @@ func init() {
 				for _, field := range ttype.Fields() {
 					fields = append(fields, field)
 				}
+
+				// Sort args so that their order is deterministic (alpha-numeric descending)
+				sort.Slice(fields, func(i, j int) bool {
+					return strings.Compare(fields[i].Name(), fields[j].Name()) == -1
+				})
+
 				return fields, nil
 			}
 			return nil, nil


### PR DESCRIPTION
Resolves #636 

Defines field args in deterministic order (alpha-numeric descending) - this means that the users will (unless their client further shuffles these) view the field args in a deterministic order.  Also massively helps testing.
