### PR TITLE
refactor: Exposed private functions necessary for schema/ast type parsing

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -1043,6 +1043,10 @@ func getFieldDef(schema Schema, parentType *Object, fieldName string) *FieldDefi
 	return parentType.Fields()[fieldName]
 }
 
+func GetFieldDef(schema Schema, parentType *Object, fieldName string) *FieldDefinition {
+	return getFieldDef(schema, parentType, fieldName)
+}
+
 // contains field information that will be placed in an ordered slice
 type orderedField struct {
 	responseName string

--- a/values.go
+++ b/values.go
@@ -443,6 +443,10 @@ func valueFromAST(valueAST ast.Value, ttype Input, variables map[string]interfac
 	return nil
 }
 
+func ValueFromAST(valueAST ast.Value, ttype Input, variables map[string]interface{}) interface{} {
+	return valueFromAST(valueAST, ttype, variables)
+}
+
 func invariant(condition bool, message string) error {
 	if !condition {
 		return gqlerrors.NewFormattedError(message)

--- a/values.go
+++ b/values.go
@@ -402,7 +402,11 @@ func valueFromAST(valueAST ast.Value, ttype Input, variables map[string]interfac
 		values := []interface{}{}
 		if valueAST, ok := valueAST.(*ast.ListValue); ok {
 			for _, itemAST := range valueAST.Values {
-				values = append(values, valueFromAST(itemAST, ttype.OfType, variables))
+				val := valueFromAST(itemAST, ttype.OfType, variables)
+				if _, ok := val.(nullValue); ok { // Null value
+					val = nil
+				}
+				values = append(values, val)
 			}
 			return values
 		}


### PR DESCRIPTION
Exposing two internal functions `ValueFromAST` and `GetFieldDef` to aid in schema to AST coorelation