### PR TITLE
feat: Add 'UTC-NOW' support to DateTime

### DIFF
--- a/scalars.go
+++ b/scalars.go
@@ -561,7 +561,13 @@ var DateTime = NewScalar(ScalarConfig{
 	ParseLiteral: func(valueAST ast.Value, variables map[string]interface{}) interface{} {
 		switch valueAST := valueAST.(type) {
 		case *ast.StringValue:
+			// Parse normal RFC3339 string
 			return unserializeDateTime(valueAST.Value)
+		case *ast.EnumValue:
+			// Support the literal `now`
+			if valueAST.Value == "now" {
+				return time.Now().UTC()
+			}
 		}
 		return nil
 	},

--- a/scalars.go
+++ b/scalars.go
@@ -555,7 +555,9 @@ func unserializeDateTime(value interface{}) interface{} {
 var DateTime = NewScalar(ScalarConfig{
 	Name: "DateTime",
 	Description: "The `DateTime` scalar type represents a DateTime." +
-		" The DateTime is serialized as an RFC 3339 quoted string",
+		" The DateTime is serialized as an RFC 3339 quoted string." +
+		" A literal value of `NOW` is supported, and will be serialized " +
+		" as the current UTC time.",
 	Serialize:  serializeDateTime,
 	ParseValue: unserializeDateTime,
 	ParseLiteral: func(valueAST ast.Value, variables map[string]interface{}) interface{} {
@@ -564,8 +566,8 @@ var DateTime = NewScalar(ScalarConfig{
 			// Parse normal RFC3339 string
 			return unserializeDateTime(valueAST.Value)
 		case *ast.EnumValue:
-			// Support the literal `now`
-			if valueAST.Value == "now" {
+			// Support the literal `NOW`
+			if valueAST.Value == "NOW" {
 				return time.Now().UTC()
 			}
 		}

--- a/scalars.go
+++ b/scalars.go
@@ -556,7 +556,7 @@ var DateTime = NewScalar(ScalarConfig{
 	Name: "DateTime",
 	Description: "The `DateTime` scalar type represents a DateTime." +
 		" The DateTime is serialized as an RFC 3339 quoted string." +
-		" A literal value of `NOW` is supported, and will be serialized " +
+		" A literal value of `UTC-NOW` is supported, and will be serialized " +
 		" as the current UTC time.",
 	Serialize:  serializeDateTime,
 	ParseValue: unserializeDateTime,
@@ -567,7 +567,7 @@ var DateTime = NewScalar(ScalarConfig{
 			return unserializeDateTime(valueAST.Value)
 		case *ast.EnumValue:
 			// Support the literal `NOW`
-			if valueAST.Value == "NOW" {
+			if valueAST.Value == "UTC-NOW" {
 				return time.Now().UTC()
 			}
 		}


### PR DESCRIPTION
This PR makes a small adjustment to the `DateTime` scalar, to allow use of a literal value, `now` which will be parsed into the current time at the time of resolution.

This will, for example, allow us to do a query like the following, over on the Defradb side of things:

 ```
 defradb client schema add '
  type ObjectWithTimestamp {
    timestamp: DateTime
  }
'

defradb client query '
  mutation {
      create_ObjectWithTimestamp(input: {timestamp: UTC-NOW}) {
          _docID
      }
  }
  `
 ```
 
 Notice that `now` is not a string, but is a literal that gets handled.
 
 This PR is proposed as the first step in resolving this issue over on Defradb: 
 
 https://github.com/sourcenetwork/defradb/issues/4152
 
 My intention is to add integration tests of this functionality on the Defradb side of things.