### PR TITLE
fix: Rename UTC-NOW to standard-conforming name

### DIFF
--- a/scalars.go
+++ b/scalars.go
@@ -556,7 +556,7 @@ var DateTime = NewScalar(ScalarConfig{
 	Name: "DateTime",
 	Description: "The `DateTime` scalar type represents a DateTime." +
 		" The DateTime is serialized as an RFC 3339 quoted string." +
-		" A literal value of `UTC-NOW` is supported, and will be serialized " +
+		" A literal value of `UTCNOW` is supported, and will be serialized " +
 		" as the current UTC time.",
 	Serialize:  serializeDateTime,
 	ParseValue: unserializeDateTime,
@@ -566,8 +566,8 @@ var DateTime = NewScalar(ScalarConfig{
 			// Parse normal RFC3339 string
 			return unserializeDateTime(valueAST.Value)
 		case *ast.EnumValue:
-			// Support the literal `NOW`
-			if valueAST.Value == "UTC-NOW" {
+			// Support the literal `UTCNOW`
+			if valueAST.Value == "UTCNOW" {
 				return time.Now().UTC()
 			}
 		}

--- a/scalars.go
+++ b/scalars.go
@@ -556,7 +556,7 @@ var DateTime = NewScalar(ScalarConfig{
 	Name: "DateTime",
 	Description: "The `DateTime` scalar type represents a DateTime." +
 		" The DateTime is serialized as an RFC 3339 quoted string." +
-		" A literal value of `UTCNOW` is supported, and will be serialized " +
+		" A literal value of `UTC_NOW` is supported, and will be serialized " +
 		" as the current UTC time.",
 	Serialize:  serializeDateTime,
 	ParseValue: unserializeDateTime,
@@ -566,8 +566,8 @@ var DateTime = NewScalar(ScalarConfig{
 			// Parse normal RFC3339 string
 			return unserializeDateTime(valueAST.Value)
 		case *ast.EnumValue:
-			// Support the literal `UTCNOW`
-			if valueAST.Value == "UTCNOW" {
+			// Support the literal `UTC_NOW`
+			if valueAST.Value == "UTC_NOW" {
 				return time.Now().UTC()
 			}
 		}

--- a/scalars.go
+++ b/scalars.go
@@ -557,7 +557,9 @@ var DateTime = NewScalar(ScalarConfig{
 	Description: "The `DateTime` scalar type represents a DateTime." +
 		" The DateTime is serialized as an RFC 3339 quoted string." +
 		" A literal value of `UTC_NOW` is supported, and will be serialized " +
-		" as the current UTC time.",
+		" as the current UTC time. Note that this will be resolved as the UTC time on" +
+		" the server's side. It may not exactly match the resolution of time.Now().UTC()" +
+        " on the client's machine at the exact time of sending the request.",	
 	Serialize:  serializeDateTime,
 	ParseValue: unserializeDateTime,
 	ParseLiteral: func(valueAST ast.Value, variables map[string]interface{}) interface{} {

--- a/scalars.go
+++ b/scalars.go
@@ -559,7 +559,7 @@ var DateTime = NewScalar(ScalarConfig{
 		" A literal value of `UTC_NOW` is supported, and will be serialized " +
 		" as the current UTC time. Note that this will be resolved as the UTC time on" +
 		" the server's side. It may not exactly match the resolution of time.Now().UTC()" +
-        " on the client's machine at the exact time of sending the request.",	
+        " on the client's machine at the time of sending the request.",	
 	Serialize:  serializeDateTime,
 	ParseValue: unserializeDateTime,
 	ParseLiteral: func(valueAST ast.Value, variables map[string]interface{}) interface{} {


### PR DESCRIPTION
This PR will rename the `UTC-NOW` literal to something that is GQL-compliant.

As per discussion in the standup, this PR goes with `UTC_NOW` using an underscore. It is important to note that there was _not_ a group consensus, but that there was a majority in agreement.