### PR TITLE
fix: Make UTC_NOW return a string

### DIFF
--- a/scalars.go
+++ b/scalars.go
@@ -561,9 +561,7 @@ var DateTime = NewScalar(ScalarConfig{
 	Description: "The `DateTime` scalar type represents a DateTime." +
 		" The DateTime is serialized as an RFC 3339 quoted string." +
 		" A literal value of `UTC_NOW` is supported, and will be serialized " +
-		" as the current UTC time. Note that this will be resolved as the UTC time on" +
-		" the server's side. It may not exactly match the resolution of time.Now().UTC()" +
-        " on the client's machine at the time of sending the request.",	
+		" as a string `UTC_NOW` which can be handled by the consumer." +
 	Serialize:  serializeDateTime,
 	ParseValue: unserializeDateTime,
 	ParseLiteral: func(valueAST ast.Value, variables map[string]interface{}) interface{} {

--- a/scalars.go
+++ b/scalars.go
@@ -9,6 +9,10 @@ import (
 	"github.com/sourcenetwork/graphql-go/language/ast"
 )
 
+const (
+	UTC_NOW = "UTC_NOW"
+)
+
 // As per the GraphQL Spec, Integers are only treated as valid when a valid
 // 32-bit signed integer, providing the broadest support across platforms.
 //
@@ -569,8 +573,8 @@ var DateTime = NewScalar(ScalarConfig{
 			return unserializeDateTime(valueAST.Value)
 		case *ast.EnumValue:
 			// Support the literal `UTC_NOW`
-			if valueAST.Value == "UTC_NOW" {
-				return time.Now().UTC()
+			if valueAST.Value == UTC_NOW {
+				return UTC_NOW
 			}
 		}
 		return nil

--- a/scalars.go
+++ b/scalars.go
@@ -561,7 +561,9 @@ var DateTime = NewScalar(ScalarConfig{
 	Description: "The `DateTime` scalar type represents a DateTime." +
 		" The DateTime is serialized as an RFC 3339 quoted string." +
 		" A literal value of `UTC_NOW` is supported, and will be serialized " +
-		" as a string `UTC_NOW` which can be handled by the consumer." +
+		" as the current UTC time. Note that this will be resolved as the UTC time on" +
+		" the server's side. It may not exactly match the resolution of time.Now().UTC()" +
+		" on the client's machine at the time of sending the request.",
 	Serialize:  serializeDateTime,
 	ParseValue: unserializeDateTime,
 	ParseLiteral: func(valueAST ast.Value, variables map[string]interface{}) interface{} {


### PR DESCRIPTION
This may seem a little odd at first, but this change is to accommodate upcoming desired changes on the Defradb side of things.

Instead of resolving `UTC_NOW` to a time here, we will return the string "UTC_NOW" and let Defradb handle it. This is to allow transactions to resolve all instances of `UTC_NOW` to the same timestamp value across the transaction.