### PR TITLE
fix: Lexer rejects schemas with multi-byte chars in comments

### DIFF
--- a/language/lexer/lexer.go
+++ b/language/lexer/lexer.go
@@ -108,13 +108,11 @@ func Lex(s *source.Source) Lexer {
 
 // Reads an alphanumeric + underscore name from the source.
 // [_A-Za-z][_0-9A-Za-z]*
-// position: Points to the byte position in the byte array
-// runePosition: Points to the rune position in the byte array
-func readName(source *source.Source, position, runePosition int) Token {
+// position is a byte offset; names are ASCII, so token Start/End are byte offsets.
+func readName(source *source.Source, position int) Token {
 	body := source.Body
 	bodyLength := len(body)
 	endByte := position + 1
-	endRune := runePosition + 1
 	for {
 		code, _ := runeAt(body, endByte)
 		if (endByte != bodyLength) &&
@@ -123,13 +121,12 @@ func readName(source *source.Source, position, runePosition int) Token {
 				code >= 'A' && code <= 'Z' || // A-Z
 				code >= 'a' && code <= 'z') { // a-z
 			endByte++
-			endRune++
 			continue
 		} else {
 			break
 		}
 	}
-	return makeToken(NAME, runePosition, endRune, string(body[position:endByte]))
+	return makeToken(NAME, position, endByte, string(body[position:endByte]))
 }
 
 // Reads a number token from the source file, either a float
@@ -233,7 +230,7 @@ func readString(s *source.Source, start int) (Token, error) {
 
 			// SourceCharacter
 			if code < 0x0020 && code != 0x0009 {
-				return Token{}, gqlerrors.NewSyntaxError(s, runePosition, fmt.Sprintf(`Invalid character within String: %v.`, printCharCode(code)))
+				return Token{}, gqlerrors.NewSyntaxError(s, position, fmt.Sprintf(`Invalid character within String: %v.`, printCharCode(code)))
 			}
 			position += n
 			runePosition++
@@ -268,7 +265,7 @@ func readString(s *source.Source, start int) (Token, error) {
 				case 'u':
 					// Check if there are at least 4 bytes available
 					if len(body) <= position+4 {
-						return Token{}, gqlerrors.NewSyntaxError(s, runePosition,
+						return Token{}, gqlerrors.NewSyntaxError(s, position,
 							fmt.Sprintf("Invalid character escape sequence: "+
 								"\\u%v", string(body[position+1:])))
 					}
@@ -279,7 +276,7 @@ func readString(s *source.Source, start int) (Token, error) {
 						rune(body[position+4]),
 					)
 					if charCode < 0 {
-						return Token{}, gqlerrors.NewSyntaxError(s, runePosition,
+						return Token{}, gqlerrors.NewSyntaxError(s, position,
 							fmt.Sprintf("Invalid character escape sequence: "+
 								"\\u%v", string(body[position+1:position+5])))
 					}
@@ -288,7 +285,7 @@ func readString(s *source.Source, start int) (Token, error) {
 					runePosition += 4
 					break
 				default:
-					return Token{}, gqlerrors.NewSyntaxError(s, runePosition,
+					return Token{}, gqlerrors.NewSyntaxError(s, position,
 						fmt.Sprintf(`Invalid character escape sequence: \\%c.`, code))
 				}
 				position += n
@@ -301,7 +298,7 @@ func readString(s *source.Source, start int) (Token, error) {
 		}
 	}
 	if code != '"' { // quote (")
-		return Token{}, gqlerrors.NewSyntaxError(s, runePosition, "Unterminated string.")
+		return Token{}, gqlerrors.NewSyntaxError(s, position, "Unterminated string.")
 	}
 	stringContent := body[chunkStart:position]
 	valueBuffer.Write(stringContent)
@@ -344,7 +341,7 @@ func readBlockString(s *source.Source, start int) (Token, error) {
 			code != 0x0009 &&
 			code != 0x000a &&
 			code != 0x000d {
-			return Token{}, gqlerrors.NewSyntaxError(s, runePosition, fmt.Sprintf(`Invalid character within String: %v.`, printCharCode(code)))
+			return Token{}, gqlerrors.NewSyntaxError(s, position, fmt.Sprintf(`Invalid character within String: %v.`, printCharCode(code)))
 		}
 
 		// Escape Triple-Quote (\""")
@@ -366,7 +363,7 @@ func readBlockString(s *source.Source, start int) (Token, error) {
 		runePosition++
 	}
 
-	return Token{}, gqlerrors.NewSyntaxError(s, runePosition, "Unterminated string.")
+	return Token{}, gqlerrors.NewSyntaxError(s, position, "Unterminated string.")
 }
 
 var splitLinesRegex = regexp.MustCompile("\r\n|[\n\r]")
@@ -482,7 +479,7 @@ func printCharCode(code rune) string {
 func readToken(s *source.Source, fromPosition int) (Token, error) {
 	body := s.Body
 	bodyLength := len(body)
-	position, runePosition := positionAfterWhitespace(body, fromPosition)
+	position := positionAfterWhitespace(body, fromPosition)
 	if position >= bodyLength {
 		return makeToken(EOF, position, position, ""), nil
 	}
@@ -490,7 +487,7 @@ func readToken(s *source.Source, fromPosition int) (Token, error) {
 
 	// SourceCharacter
 	if code < 0x0020 && code != 0x0009 && code != 0x000A && code != 0x000D {
-		return Token{}, gqlerrors.NewSyntaxError(s, runePosition, fmt.Sprintf(`Invalid character %v`, printCharCode(code)))
+		return Token{}, gqlerrors.NewSyntaxError(s, position, fmt.Sprintf(`Invalid character %v`, printCharCode(code)))
 	}
 
 	switch code {
@@ -544,12 +541,12 @@ func readToken(s *source.Source, fromPosition int) (Token, error) {
 	// A-Z
 	case 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N',
 		'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z':
-		return readName(s, position, runePosition), nil
+		return readName(s, position), nil
 	// _
 	// a-z
 	case '_', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
 		'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z':
-		return readName(s, position, runePosition), nil
+		return readName(s, position), nil
 	// -
 	// 0-9
 	case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
@@ -572,7 +569,7 @@ func readToken(s *source.Source, fromPosition int) (Token, error) {
 		return token, err
 	}
 	description := fmt.Sprintf("Unexpected character %v.", printCharCode(code))
-	return Token{}, gqlerrors.NewSyntaxError(s, runePosition, description)
+	return Token{}, gqlerrors.NewSyntaxError(s, position, description)
 }
 
 // Gets the rune from the byte array at given byte position and it's width in bytes
@@ -591,22 +588,13 @@ func runeAt(body []byte, position int) (code rune, charWidth int) {
 	return r, n
 }
 
-// Reads from body starting at startPosition until it finds a non-whitespace
-// or commented character, then returns the position of that character for lexing.
-// lexing.
-//
-// Both return values are byte offsets into body. The second value is retained
-// for API compatibility (callers historically treated it as a "rune position"),
-// but it MUST advance in lockstep with the byte position: token Start/End offsets
-// are consumed as byte offsets everywhere else (GetLocation indexes body with
-// them, and the parser feeds Token.End back as the byte start of the next read).
-// Advancing by 1 per rune here would make the two values diverge as soon as an
-// ignored token (whitespace or a # comment) contains a multi-byte UTF-8 rune,
-// shifting every subsequent token and producing spurious syntax errors.
-func positionAfterWhitespace(body []byte, startPosition int) (position int, runePosition int) {
+// Skips leading whitespace and comments and returns the byte position of the
+// next character to lex. It advances by each rune's byte width, not one per
+// rune: token offsets are byte offsets everywhere, so counting runes here would
+// drift on any multi-byte rune in an ignored token and shift every later token.
+func positionAfterWhitespace(body []byte, startPosition int) int {
 	bodyLength := len(body)
-	position = startPosition
-	runePosition = startPosition
+	position := startPosition
 	for {
 		if position < bodyLength {
 			code, n := runeAt(body, position)
@@ -622,10 +610,8 @@ func positionAfterWhitespace(body []byte, startPosition int) (position int, rune
 				// Comma
 				code == 0x002C {
 				position += n
-				runePosition += n
 			} else if code == 35 { // #
 				position += n
-				runePosition += n
 				for {
 					code, n := runeAt(body, position)
 					if position < bodyLength &&
@@ -633,7 +619,6 @@ func positionAfterWhitespace(body []byte, startPosition int) (position int, rune
 						// SourceCharacter but not LineTerminator
 						(code > 0x001F || code == 0x0009) && code != 0x000A && code != 0x000D {
 						position += n
-						runePosition += n
 						continue
 					} else {
 						break
@@ -647,7 +632,7 @@ func positionAfterWhitespace(body []byte, startPosition int) (position int, rune
 			break
 		}
 	}
-	return position, runePosition
+	return position
 }
 
 func GetTokenDesc(token Token) string {

--- a/language/lexer/lexer.go
+++ b/language/lexer/lexer.go
@@ -594,7 +594,15 @@ func runeAt(body []byte, position int) (code rune, charWidth int) {
 // Reads from body starting at startPosition until it finds a non-whitespace
 // or commented character, then returns the position of that character for lexing.
 // lexing.
-// Returns both byte positions and rune position
+//
+// Both return values are byte offsets into body. The second value is retained
+// for API compatibility (callers historically treated it as a "rune position"),
+// but it MUST advance in lockstep with the byte position: token Start/End offsets
+// are consumed as byte offsets everywhere else (GetLocation indexes body with
+// them, and the parser feeds Token.End back as the byte start of the next read).
+// Advancing by 1 per rune here would make the two values diverge as soon as an
+// ignored token (whitespace or a # comment) contains a multi-byte UTF-8 rune,
+// shifting every subsequent token and producing spurious syntax errors.
 func positionAfterWhitespace(body []byte, startPosition int) (position int, runePosition int) {
 	bodyLength := len(body)
 	position = startPosition
@@ -614,10 +622,10 @@ func positionAfterWhitespace(body []byte, startPosition int) (position int, rune
 				// Comma
 				code == 0x002C {
 				position += n
-				runePosition++
+				runePosition += n
 			} else if code == 35 { // #
 				position += n
-				runePosition++
+				runePosition += n
 				for {
 					code, n := runeAt(body, position)
 					if position < bodyLength &&
@@ -625,7 +633,7 @@ func positionAfterWhitespace(body []byte, startPosition int) (position int, rune
 						// SourceCharacter but not LineTerminator
 						(code > 0x001F || code == 0x0009) && code != 0x000A && code != 0x000D {
 						position += n
-						runePosition++
+						runePosition += n
 						continue
 					} else {
 						break

--- a/language/lexer/lexer_test.go
+++ b/language/lexer/lexer_test.go
@@ -2,6 +2,7 @@ package lexer
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/sourcenetwork/graphql-go/language/source"
@@ -1104,6 +1105,38 @@ func TestLexer_SkipsMultiByteRunesInIgnoredTokens(t *testing.T) {
 		}
 		if !reflect.DeepEqual(token, test.Expected) {
 			t.Errorf("unexpected token, expected: %v, got: %v, body: %q", test.Expected, token, test.Body)
+		}
+	}
+}
+
+// Error columns count characters, not bytes: a multi-byte rune before the error
+// advances the column by one, matching what an editor shows.
+func TestLexer_ErrorColumnCountsCharactersNotBytes(t *testing.T) {
+	tests := []struct {
+		body     string
+		expected string
+	}{
+		{
+			// Two 3-byte em-dashes in a comment; the invalid char is char 7.
+			body:     "# — — \x00",
+			expected: `Syntax Error  (1:7) Invalid character "\\u0000"`,
+		},
+		{
+			// Multi-byte runes in a string; the bad escape is char 12.
+			body:     "\"bфы世ыы𠱸d \\uXXXF esc\"",
+			expected: `Syntax Error  (1:12) Invalid character escape sequence: \uXXXF`,
+		},
+	}
+	for _, test := range tests {
+		_, err := Lex(&source.Source{Body: []byte(test.body)})(0)
+		if err == nil {
+			t.Errorf("expected error, got nil, body: %q", test.body)
+			continue
+		}
+		// Compare only the first line; the escape error appends a caret diagram.
+		got := strings.SplitN(err.Error(), "\n", 2)[0]
+		if got != test.expected {
+			t.Errorf("unexpected error\nexpected: %q\ngot:      %q\nbody: %q", test.expected, got, test.body)
 		}
 	}
 }

--- a/language/lexer/lexer_test.go
+++ b/language/lexer/lexer_test.go
@@ -88,11 +88,12 @@ func TestLexer_DisallowsUncommonControlCharacters(t *testing.T) {
 func TestLexer_AcceptsBOMHeader(t *testing.T) {
 	tests := []Test{
 		{
+			// The BOM is 3 bytes, so after it and the space "foo" is at bytes 4:7.
 			Body: "\uFEFF foo",
 			Expected: Token{
 				Kind:  NAME,
-				Start: 2,
-				End:   5,
+				Start: 4,
+				End:   7,
 				Value: "foo",
 			},
 		},
@@ -1067,5 +1068,42 @@ func TestLexer_ReportsUsefulInformationForDashesInNames(t *testing.T) {
 	}
 	if err.Error() != errExpected {
 		t.Fatalf("unexpected error, token:%v\nexpected:\n%v\n\ngot:\n%v", token, errExpected, err.Error())
+	}
+}
+
+// A multi-byte character in a comment or whitespace must not move the byte
+// offsets of the next token. Start/End are byte offsets, so the lexer must
+// skip such a character by its byte count, not count it as one.
+func TestLexer_SkipsMultiByteRunesInIgnoredTokens(t *testing.T) {
+	tests := []Test{
+		{
+			// The em-dash is 3 bytes, so "foo" is at bytes 6:9.
+			Body: "# —\nfoo",
+			Expected: Token{
+				Kind:  NAME,
+				Start: 6,
+				End:   9,
+				Value: "foo",
+			},
+		},
+		{
+			// Two em-dashes (3 bytes each) push "foo" to bytes 10:13.
+			Body: "# — —\nfoo",
+			Expected: Token{
+				Kind:  NAME,
+				Start: 10,
+				End:   13,
+				Value: "foo",
+			},
+		},
+	}
+	for _, test := range tests {
+		token, err := Lex(&source.Source{Body: []byte(test.Body)})(0)
+		if err != nil {
+			t.Errorf("unexpected error: %v, body: %q", err, test.Body)
+		}
+		if !reflect.DeepEqual(token, test.Expected) {
+			t.Errorf("unexpected token, expected: %v, got: %v, body: %q", test.Expected, token, test.Body)
+		}
 	}
 }

--- a/language/location/location.go
+++ b/language/location/location.go
@@ -2,6 +2,7 @@ package location
 
 import (
 	"regexp"
+	"unicode/utf8"
 
 	"github.com/sourcenetwork/graphql-go/language/source"
 )
@@ -11,25 +12,36 @@ type SourceLocation struct {
 	Column int `json:"column"`
 }
 
+// GetLocation maps a byte offset to a 1-based line and column. position is a
+// byte offset (matching token Start/End), but the column counts runes, so it
+// matches the character column an editor shows.
 func GetLocation(s *source.Source, position int) SourceLocation {
 	body := []byte{}
 	if s != nil {
 		body = s.Body
 	}
 	line := 1
-	column := position + 1
+	lineStart := 0
 	lineRegexp := regexp.MustCompile("\r\n|[\n\r]")
 	matches := lineRegexp.FindAllIndex(body, -1)
 	for _, match := range matches {
 		matchIndex := match[0]
 		if matchIndex < position {
 			line++
-			l := len(s.Body[match[0]:match[1]])
-			column = position + 1 - (matchIndex + l)
+			lineStart = match[1]
 			continue
 		} else {
 			break
 		}
+	}
+	// Clamp to body so a position past the end (e.g. EOF) does not panic.
+	end := position
+	if end > len(body) {
+		end = len(body)
+	}
+	column := 1
+	if lineStart < end {
+		column = utf8.RuneCount(body[lineStart:end]) + 1
 	}
 	return SourceLocation{Line: line, Column: column}
 }

--- a/language/location/location_test.go
+++ b/language/location/location_test.go
@@ -1,0 +1,66 @@
+package location
+
+import (
+	"testing"
+
+	"github.com/sourcenetwork/graphql-go/language/source"
+)
+
+func TestGetLocation(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		position int // byte offset
+		expected SourceLocation
+	}{
+		{
+			name:     "start of input",
+			body:     "foo",
+			position: 0,
+			expected: SourceLocation{Line: 1, Column: 1},
+		},
+		{
+			name:     "ascii column counts characters",
+			body:     "foo bar",
+			position: 4,
+			expected: SourceLocation{Line: 1, Column: 5},
+		},
+		{
+			name:     "second line resets column",
+			body:     "foo\nbar",
+			position: 4, // 'b'
+			expected: SourceLocation{Line: 2, Column: 1},
+		},
+		{
+			// The 3-byte em-dash before 'b' counts as one column, not three.
+			name:     "multi-byte rune counts as one column",
+			body:     "a — b", // 'b' is byte 6, char column 5
+			position: 6,
+			expected: SourceLocation{Line: 1, Column: 5},
+		},
+		{
+			// Position past the end (e.g. EOF) must not panic.
+			name:     "position past end of body",
+			body:     "ab",
+			position: 5,
+			expected: SourceLocation{Line: 1, Column: 3},
+		},
+		{
+			name:     "nil-safe with empty body",
+			body:     "",
+			position: 0,
+			expected: SourceLocation{Line: 1, Column: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &source.Source{Body: []byte(tt.body)}
+			got := GetLocation(s, tt.position)
+			if got != tt.expected {
+				t.Errorf("GetLocation(%q, %d) = %+v, want %+v",
+					tt.body, tt.position, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A leading comment containing any multi-byte UTF-8 character — an em-dash, a curly quote, an accented letter, an emoji — caused the lexer to reject an otherwise-valid document with a misleading syntax error like `Expected {, found Name "Foo"`. The same document with an ASCII-only comment parsed fine.

While skipping whitespace and comments, the lexer counted each character as one position instead of advancing by its byte width. Token offsets are byte offsets everywhere else, so a multi-byte character inside an ignored stretch shifted every following token and eventually made the parser misread punctuation as a name. The fix advances by the character's byte width while skipping, keeping the position in step with the bytes.

This surfaced on the DefraDB side when schema files carried documentation comments with typographic punctuation.