### PR TITLE
fix: synchronize input object field initialization

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/sourcenetwork/graphql-go/language/ast"
 )
@@ -1146,6 +1147,7 @@ type InputObject struct {
 
 	typeConfig InputObjectConfig
 	fields     InputObjectFieldMap
+	fieldsOnce sync.Once
 	init       bool
 	err        error
 }
@@ -1272,9 +1274,11 @@ func (gt *InputObject) AddFieldConfig(fieldName string, fieldConfig *InputObject
 }
 
 func (gt *InputObject) Fields() InputObjectFieldMap {
-	if !gt.init {
-		gt.fields = gt.defineFieldMap()
-	}
+	gt.fieldsOnce.Do(func() {
+		if !gt.init {
+			gt.fields = gt.defineFieldMap()
+		}
+	})
 	return gt.fields
 }
 func (gt *InputObject) Name() string {

--- a/definition_test.go
+++ b/definition_test.go
@@ -3,6 +3,8 @@ package graphql_test
 import (
 	"fmt"
 	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/sourcenetwork/graphql-go"
@@ -665,6 +667,48 @@ func TestTypeSystem_DefinitionExample_CanAddInputObjectField(t *testing.T) {
 	}
 	if _, ok := fieldMap["newValue"]; !ok {
 		t.Fatal("Unexpected result, inputObject should have a field named 'newValue'")
+	}
+}
+
+func TestTypeSystem_DefinitionExample_InitializesInputObjectFieldsOnce(t *testing.T) {
+	const workers = 32
+	var calls int32
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	io := graphql.NewInputObject(graphql.InputObjectConfig{
+		Name: "inputObject",
+		Fields: graphql.InputObjectConfigFieldMapThunk(func() (graphql.InputObjectConfigFieldMap, error) {
+			if atomic.AddInt32(&calls, 1) == 1 {
+				close(entered)
+			}
+			<-release
+			return graphql.InputObjectConfigFieldMap{
+				"value": &graphql.InputObjectFieldConfig{Type: graphql.String},
+			}, nil
+		}),
+	})
+
+	fields := make(chan graphql.InputObjectFieldMap, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			fields <- io.Fields()
+		}()
+	}
+	<-entered
+	close(release)
+	wg.Wait()
+	close(fields)
+
+	if atomic.LoadInt32(&calls) != 1 {
+		t.Fatalf("field thunk called %d times, want 1", atomic.LoadInt32(&calls))
+	}
+	for fieldMap := range fields {
+		if fieldMap["value"].Type != graphql.String {
+			t.Fatal("input object field was not initialized")
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- initialize lazy input object fields once under concurrent access
- cover concurrent first access with a race-enabled regression test

## Validation

- `go test -race ./ -run InputObject -count=20`
- `go vet ./...`
- Trust API `TestDefraStore_APIKeyLimitIsAtomic` without initialization warm-up:
  - current dependency reproduces the `InputObject.defineFieldMap` race
  - this branch passes 20 consecutive runs
- Trust API `go test -race ./internal/store`
